### PR TITLE
[Fix] 커스텀 입력 시 불필요한 예제 결과 비교 제거 및 UI 개선

### DIFF
--- a/client/src/components/IDE.tsx
+++ b/client/src/components/IDE.tsx
@@ -107,8 +107,10 @@ export function IDE({ problem }: IDEProps) {
     }
   };
 
-  const expectedOutput = problem.testCases?.find((t: TestCase) => t.sampleNumber === selectedTestCase)?.expectedOutput;
-  const isCorrect = output.trim() === expectedOutput?.trim();
+  const currentTestCase = problem.testCases?.find((t: TestCase) => t.sampleNumber === selectedTestCase);
+  const expectedOutput = currentTestCase?.expectedOutput;
+  const isInputMatched = customInput.trim() === currentTestCase?.input?.trim();
+  const isCorrect = isInputMatched && output.trim() === expectedOutput?.trim();
 
   return (
     <div className="h-[calc(100vh-2rem)] flex flex-col bg-[#1e1e1e] rounded-xl overflow-hidden shadow-2xl border border-white/5">
@@ -252,7 +254,7 @@ export function IDE({ problem }: IDEProps) {
 
               {activeTab === 'output' && (
                 <div className="space-y-4">
-                  {output && expectedOutput && (
+                  {output && expectedOutput && isInputMatched && (
                     <div className={cn(
                       "flex items-center gap-2 px-3 py-2 rounded-lg border",
                       isCorrect
@@ -265,9 +267,16 @@ export function IDE({ problem }: IDEProps) {
                       </span>
                     </div>
                   )}
+                  {!isInputMatched && (
+                    <div className="bg-secondary/20 p-3 rounded border border-white/5 space-y-1">
+                      <div className="text-[10px] text-muted-foreground uppercase font-semibold">사용한 입력 (Current Input)</div>
+                      <pre className="text-xs font-mono text-muted-foreground truncate italic">{customInput || "(입력 없음)"}</pre>
+                    </div>
+                  )}
                   <div className="font-mono text-sm">
+                    <div className="text-[10px] text-muted-foreground uppercase mb-2 font-semibold">실행 결과 (Result)</div>
                     {output ? (
-                      <pre className="text-gray-300 whitespace-pre-wrap py-2">{output}</pre>
+                      <pre className="text-gray-300 whitespace-pre-wrap py-2 p-3 bg-black/20 rounded border border-white/5">{output}</pre>
                     ) : (
                       <div className="text-muted-foreground italic py-2">실행 버튼을 눌러 결과를 확인하세요...</div>
                     )}


### PR DESCRIPTION
## 💡 개요
사용자가 입력을 직접 수정했을 때 예제 결과와 잘못 비교되는 문제를 해결하고, 출력 탭에서 어떤 입력이 사용되었는지 확인할 수 있도록 개선했습니다.

## 🔗 관련 이슈
- #6
- #7

## 🛠️ 작업 내용
- **입력 일치 확인**: 이 선택된 예제 입력과 다를 경우  플래그를 통해 결과 비교 메시지를 숨기도록 처리했습니다.
- **출력 탭 개선**: 
    - 입력을 수정한 경우(커스텀 입력), 출력 탭 상단에 '사용한 입력' 요약을 보여주어 가독성을 높였습니다.
    - 실행 결과를 박스 형태로 감싸고 레이블을 추가하여 시각적으로 구분했습니다.

## 🧪 테스트 결과
1. **예제 실행**: 예제와 입력이 같을 때는 기존처럼 '결과가 일치합니다' 메시지가 정상 표시됨.
2. **커스텀 입력**: 입력을 수정하고 실행하면 비교 메시지 대신 '사용한 입력' 정보가 표시되며 실행 결과만 노출됨.

Closes #6
Closes #7