### PR TITLE
feat: translate problem tags to Korean (#15)

### DIFF
--- a/server/src/main/java/com/algoarena/service/BOJSyncService.java
+++ b/server/src/main/java/com/algoarena/service/BOJSyncService.java
@@ -104,30 +104,31 @@ public class BOJSyncService {
     private String extractTagsFromJson(String json) {
         List<String> tags = new ArrayList<>();
         // Solved.ac tags structure: "tags": [{"key": "math", "displayNames":
-        // [{"language": "ko", "name": "수학"}, {"language": "en", "name":
-        // "mathematics"}]}]
-        // We'll look for language: "ko" names.
-        // A more robust way would be using ObjectMapper, but keeping it simple with
-        // regex for now.
+        // [{"language": "ko", "name": "수학"}, ...
 
+        // Find each tag object in the tags array
         java.util.regex.Pattern tagPattern = java.util.regex.Pattern
-                .compile("\\{\"key\":\"([^\"]+)\".*?\"displayNames\":\\[(.*?)\\]");
-        java.util.regex.Matcher tagMatcher = tagPattern.matcher(json.replace(" ", ""));
+                .compile("\\{\"key\":.*?\"displayNames\":\\[(.*?)\\]");
+        java.util.regex.Matcher tagMatcher = tagPattern.matcher(json);
 
         while (tagMatcher.find()) {
-            String koName = null;
-            String displayNames = tagMatcher.group(2);
-            java.util.regex.Pattern koPattern = java.util.regex.Pattern
-                    .compile("\\{\"language\":\"ko\",\"name\":\"([^\"]+)\"\\}");
-            java.util.regex.Matcher koMatcher = koPattern.matcher(displayNames);
-            if (koMatcher.find()) {
-                koName = koMatcher.group(1);
-            }
+            String displayNames = tagMatcher.group(1);
 
-            if (koName != null) {
-                tags.add(koName);
+            // Try to find the Korean name first
+            java.util.regex.Pattern koPattern = java.util.regex.Pattern
+                    .compile("\\{\"language\":\"ko\",\"name\":\"([^\"]+)\"");
+            java.util.regex.Matcher koMatcher = koPattern.matcher(displayNames);
+
+            if (koMatcher.find()) {
+                tags.add(koMatcher.group(1));
             } else {
-                tags.add(tagMatcher.group(1)); // Fallback to key
+                // Fallback: search for English name if Korean is not found
+                java.util.regex.Pattern enPattern = java.util.regex.Pattern
+                        .compile("\\{\"language\":\"en\",\"name\":\"([^\"]+)\"");
+                java.util.regex.Matcher enMatcher = enPattern.matcher(displayNames);
+                if (enMatcher.find()) {
+                    tags.add(enMatcher.group(1));
+                }
             }
         }
         return String.join(",", tags);


### PR DESCRIPTION
## 개요
문제 동기화 시 수집되는 알고리즘 태그를 한국어로 변환하여 사용자 경험을 개선했습니다.

## 주요 변경 사항
- **BAEKJOON 온라인 저지 동기화 로직 개선**:
  - `BOJSyncService.java`의 `extractTagsFromJson` 메서드를 수정했습니다.
  - JSON 응답 내 `tags -> displayNames` 구조에서 `language: ko`인 항목을 우선적으로 파싱합니다.
  - 정규식을 보강하여 JSON 구조 변화에 더 강건하게 대응하도록 개선했습니다.
- **다국어 대응**: 한국어 명칭이 없는 경우 영문 명칭(`language: en`)을 가져오도록 폴백(Fallback) 구조를 설계했습니다.

## 검증 내용
- **기능 테스트**: 실제 문제 ID(예: 1000, 1001 등)를 입력하여 동기화했을 때 태그가 '구현', '수학' 등 한국어로 정상 저장 및 표시되는지 확인했습니다.
- **빌드 테스트**: `./gradlew classes`를 통해 컴파일 오류 없음을 검증했습니다.

Closes #15