### PR TITLE
Fix: 실행 중 결과 숨김 및 초기화 로직 수정

### DIFF
--- a/client/src/components/IDE.tsx
+++ b/client/src/components/IDE.tsx
@@ -108,6 +108,8 @@ export function IDE({ problem }: IDEProps) {
   const handleRun = async () => {
     setIsRunning(true);
     setActiveTab('output');
+    setOutput(""); // 실행 시 이전 출력 초기화
+    setTestResults({}); // 이전 테스트 결과 초기화
     try {
       const result = await runCode.mutateAsync({
         code,
@@ -334,7 +336,7 @@ export function IDE({ problem }: IDEProps) {
 
               {activeTab === 'output' && (
                 <div className="space-y-4">
-                  {output && expectedOutput && isInputMatched && (
+                  {output && expectedOutput && isInputMatched && !isRunning && (
                     <div className={cn(
                       "flex items-center gap-2 px-3 py-2 rounded-lg border",
                       isCorrect


### PR DESCRIPTION
## 변경 사항 (Changes)
- `handleRun` 함수 시작 시 `setOutput("")` 외에 `setTestResults({})`를 호출하여 이전 실행 결과와 테스트 상태를 모두 초기화합니다.
- 결과 비교 UI(CheckCircle2/AlertCircle)가 `!isRunning` 조건일 때만 렌더링되도록 수정했습니다.

## 해결된 문제 (Resolved Issues)
- 런타임 중 이전 결과가 화면에 남아 사용자에게 혼란을 주는 문제를 해결했습니다.
- 재실행 시 이전의 성공/실패 상태가 즉시 사라집니다.

## 관련 이슈 (Related Issue)
- Closes #23
