### PR TITLE
fix: remove auto-switch to input tab on example click (re-apply)

### DIFF
--- a/client/src/components/IDE.tsx
+++ b/client/src/components/IDE.tsx
@@ -93,7 +93,7 @@ export function IDE({ problem }: IDEProps) {
     if (tc) {
       setSelectedTestCase(sampleNum);
       setCustomInput(tc.input);
-      setActiveTab('input');
+      // setActiveTab('input'); // Removed to prevent auto-switching
     }
   };
 


### PR DESCRIPTION
## 변경 사항
- `client/src/components/IDE.tsx`: 예제 클릭 시 `Input` 탭으로 자동 전환되는 코드를 다시 제거했습니다.

## 상세 내용
- 이전 작업 내용이 유실된 것을 확인하여 다시 적용했습니다.
- `handleSelectSample` 함수에서 `setActiveTab('input')` 호출을 제거했습니다.

## 테스트 방법
1. 문제 풀이 화면에서 예제 버튼 클릭.
2. `Input` 탭으로 전환되지 않는지 확인.

Closes #31
