### PR TITLE
feat: enhance output tab with side-by-side comparison and loading state

### DIFF
--- a/client/src/components/IDE.tsx
+++ b/client/src/components/IDE.tsx
@@ -361,14 +361,48 @@ export function IDE({ problem }: IDEProps) {
                       <pre className="text-xs font-mono text-muted-foreground truncate italic">{customInput || "(입력 없음)"}</pre>
                     </div>
                   )}
-                  <div className="font-mono text-sm">
-                    <div className="text-[10px] text-muted-foreground uppercase mb-2 font-semibold">실행 결과 (Result)</div>
-                    {output ? (
-                      <pre className="text-gray-300 whitespace-pre-wrap py-2 p-3 bg-black/20 rounded border border-white/5">{output}</pre>
-                    ) : (
-                      <div className="text-muted-foreground italic py-2">실행 버튼을 눌러 결과를 확인하세요...</div>
-                    )}
-                  </div>
+                  {expectedOutput ? (
+                    <div className="grid grid-cols-2 gap-4 font-mono">
+                      <div className="space-y-2">
+                        <label className="text-[10px] text-muted-foreground uppercase font-semibold">예상 결과 (Expected Output)</label>
+                        <pre className="p-4 pb-8 bg-black/50 rounded-md border border-white/10 text-xs font-mono whitespace-pre-wrap text-green-400/80">
+                          {expectedOutput}
+                        </pre>
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-[10px] text-muted-foreground uppercase font-semibold">실행 결과 (Actual Result)</label>
+                        {isRunning ? (
+                          <div className="p-4 pb-8 bg-black/50 rounded-md border border-white/10 text-xs font-mono text-muted-foreground flex items-center gap-2">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            <span>실행 중...</span>
+                          </div>
+                        ) : (
+                          <pre className={cn(
+                            "p-4 pb-8 bg-black/50 rounded-md border border-white/10 text-xs font-mono whitespace-pre-wrap",
+                            isCorrect ? "text-green-400" : "text-red-400"
+                          )}>
+                            {output || "(결과 없음)"}
+                          </pre>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="font-mono text-sm">
+                      <div className="text-[10px] text-muted-foreground uppercase mb-2 font-semibold">실행 결과 (Result)</div>
+                      {isRunning ? (
+                        <div className="p-4 pb-8 bg-black/50 rounded-md border border-white/10 text-xs font-mono text-muted-foreground flex items-center gap-2">
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          <span>실행 중...</span>
+                        </div>
+                      ) : output ? (
+                        <pre className="p-4 pb-8 bg-black/50 rounded-md border border-white/10 text-xs font-mono whitespace-pre-wrap text-gray-300">
+                          {output}
+                        </pre>
+                      ) : (
+                        <div className="text-muted-foreground italic py-2">실행 버튼을 눌러 결과를 확인하세요...</div>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </ScrollArea>


### PR DESCRIPTION
## 💡 개요

IDE의 출력(Output) 탭 UI를 개선하여, 예제 실행 시 예상 결과와 실제 결과를 직관적으로 비교할 수 있도록 하고, 실행 중 로딩 상태를 추가하여 사용자 경험을 향상시켰습니다.

## 🔗 관련 이슈

• Closes #35

## 🛠️ 작업 내용

• 프론트엔드:
  • `IDE.tsx`:
    • **Side-by-Side Output Comparison**: `activeTab === 'output'` 영역을 2열 그리드로 변경하여 예상 결과와 실제 결과를 나란히 표시하도록 구현.
    • **Loading Indicator**: `isRunning` 상태를 활용하여, 실행 중일 때 로딩 스피너(`Loader2`)와 "실행 중..." 텍스트를 표시하도록 개선.
    • **UI Styling**: 기존 '예제 선택' 탭의 스타일(`bg-black/50`, `p-4`, `pb-8`)을 동일하게 적용하여 디자인 일관성 확보.

## 🧪 테스트 결과

• **예제 실행 (정답)**: 좌측(예상)과 우측(실제) 결과가 나란히 표시되며, 실제 결과가 초록색으로 표시됨을 확인.
• **예제 실행 (오답)**: 실제 결과가 빨간색으로 표시되어 예상 결과와 비교 가능함을 확인.
• **로딩 상태**: '실행' 버튼 클릭 시 즉시 로딩 스피너가 표시되고, 결과 수신 후 사라짐을 확인.
