### PR TITLE
feat: implement relaxed output comparison (ignore trailing whitespace/newlines)

### DIFF
--- a/client/src/components/IDE.tsx
+++ b/client/src/components/IDE.tsx
@@ -27,6 +27,18 @@ int main() {
 }
 `;
 
+// Output normalization function to relax comparison (ignore trailing whitespace and extra newlines)
+const normalizeOutput = (str: string | null | undefined) => {
+  if (!str) return "";
+  return str
+    .trim()
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.trimEnd()) // Remove trailing whitespace from each line
+    .filter(line => line.trim() !== "") // Remove empty lines
+    .join('\n');
+};
+
 export function IDE({ problem }: IDEProps) {
   const [code, setCode] = useState(DEFAULT_CODE);
   const [output, setOutput] = useState("");
@@ -72,7 +84,7 @@ export function IDE({ problem }: IDEProps) {
         });
 
         const output = result.success ? (result.output || "") : (result.error || result.output || "실행 오류");
-        const isCorrect = output.trim() === tc.expectedOutput?.trim();
+        const isCorrect = normalizeOutput(output) === normalizeOutput(tc.expectedOutput);
 
         setTestResults(prev => ({
           ...prev,
@@ -147,7 +159,7 @@ export function IDE({ problem }: IDEProps) {
   const isInputMatched = customInput.trim() === currentTestCase?.input?.trim();
 
   const isError = output.startsWith("에러:") || output === "실행 오류" || output.includes("Error:") || output.includes("RuntimeException");
-  const isCorrect = !isError && isInputMatched && output.trim() === expectedOutput?.trim();
+  const isCorrect = !isError && isInputMatched && normalizeOutput(output) === normalizeOutput(expectedOutput);
 
   return (
     <div className="h-[calc(100vh-2rem)] flex flex-col bg-[#1e1e1e] rounded-xl overflow-hidden shadow-2xl border border-white/5">


### PR DESCRIPTION
## 💡 개요
출력 검증 로직을 개선하여, 정답 비교 시 불필요한 공백과 줄바꿈을 무시하도록 변경했습니다. 이를 통해 사용자가 정답 포맷을 완벽하게 맞추지 않아도(예: 끝에 엔터 추가 등) 의미가 같으면 정답으로 인정되도록 합니다.

## 🔗 관련 이슈
• Closes #37

## 🛠️ 작업 내용
• 프론트엔드:
  • `IDE.tsx`:
    • `normalizeOutput` 함수 추가 (공백/줄바꿈 정규화).
    • `isCorrect` (단일 실행) 및 `handleRunAll` (전체 실행)에서 정답 비교 시 `normalizeOutput`을 사용하도록 수정.

## 🧪 테스트 결과
• **단일 실행**: 정답 뒤에 스페이스바나 엔터를 여러 번 입력해도 **정답(초록색)** 처리됨을 확인.
• **전체 실행**: '전체 실행' 시에도 동일하게 완화된 로직이 적용되어 정상적으로 통과됨을 확인.
