### PR TITLE
[Fix] 보안 및 크리티컬 버그 패치: 코드 실행 샌드박스 강화, API 파라미터 혼동 수정, HTTP 240→204

### DIFF
--- a/client/src/hooks/use-problems.ts
+++ b/client/src/hooks/use-problems.ts
@@ -23,11 +23,11 @@ export function useProblems(filters?: { search?: string; category?: string; tier
   });
 }
 
-export function useProblem(id: number) {
+export function useProblem(bojId: number) {
   return useQuery({
-    queryKey: [api.problems.get.path, id],
+    queryKey: [api.problems.get.path, bojId],
     queryFn: async () => {
-      const url = buildUrl(api.problems.get.path, { id });
+      const url = buildUrl(api.problems.get.path, { bojId });
       const res = await fetch(url, { credentials: "include" });
       if (res.status === 404) return null;
       if (!res.ok) throw new Error("Failed to fetch problem");
@@ -35,7 +35,7 @@ export function useProblem(id: number) {
       const data = await res.json();
       return api.problems.get.responses[200].parse(data);
     },
-    enabled: !!id,
+    enabled: !!bojId,
   });
 }
 

--- a/client/src/pages/Problems.tsx
+++ b/client/src/pages/Problems.tsx
@@ -221,7 +221,7 @@ export default function Problems() {
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>
-                  <Link href={`/solve/${problem.id}`}>
+                  <Link href={`/solve/${problem.bojId}`}>
                     <Button variant="secondary" className="group/btn">
                       Solve <ArrowRight className="ml-2 w-4 h-4 group-hover/btn:translate-x-1 transition-transform" />
                     </Button>

--- a/server/src/main/java/com/algoarena/controller/ProblemController.java
+++ b/server/src/main/java/com/algoarena/controller/ProblemController.java
@@ -21,10 +21,10 @@ public class ProblemController {
         return problemRepository.findAll();
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<Problem> getProblem(@PathVariable Integer id) {
+    @GetMapping("/{bojId}")
+    public ResponseEntity<Problem> getProblem(@PathVariable Integer bojId) {
         try {
-            return ResponseEntity.ok(problemService.getOrScrapeProblem(id));
+            return ResponseEntity.ok(problemService.getOrScrapeProblem(bojId));
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.notFound().build();

--- a/shared/routes.ts
+++ b/shared/routes.ts
@@ -30,7 +30,7 @@ export const api = {
     },
     get: {
       method: 'GET' as const,
-      path: '/api/problems/:id',
+      path: '/api/problems/:bojId',
       responses: {
         200: z.custom<Problem>(),
         404: errorSchemas.notFound,
@@ -50,7 +50,7 @@ export const api = {
       method: "DELETE" as const,
       path: "/api/problems/:id",
       responses: {
-        240: z.void(), // Changed from 204 because 204 is no content
+        204: z.void(),
         404: errorSchemas.notFound,
       },
     },


### PR DESCRIPTION
## 요약

코드 리뷰 결과 발견된 **보안 취약점** 및 **크리티컬 버그** 3건을 수정합니다.

Closes #43

---

## 변경 사항

### 1. CompilerService.java — 코드 실행 샌드박스 강화

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| 파일 격리 | 공용 `/tmp`에 직접 생성 | 고유 서브디렉토리 `algoarena-{uuid}` 격리 |
| 프로세스 종료 | `process.destroy()` | `process.destroyForcibly()` (자식 프로세스 포함) |
| 컴파일 타임아웃 | 5초 | 10초 (복잡한 문제 대응) |
| 실행 타임아웃 | 2초 + RuntimeException | 10초 + CompileResponse로 정상 응답 |
| 출력 제한 | 무제한 | 64KB 제한 (무한 출력 방지) |
| 중복 분기 | 언어별 if-else 2회 반복 (90~116행) | `buildRunProcessBuilder()` 메서드 추출 |
| 리소스 정리 | 개별 파일 삭제 | 디렉토리 전체 삭제 (`cleanupSandbox()`) |

### 2. ProblemController + Problems.tsx — URL 파라미터 혼동 수정

**문제**: `GET /api/problems/{id}`에서 `{id}`가 BOJ 문제 번호로 사용되는데, `Problems.tsx`에서는 DB PK(`problem.id`)로 네비게이션하여 엉뚱한 문제가 조회됨

- `ProblemController.java`: `@PathVariable Integer id` → `@PathVariable Integer bojId`로 명확화
- `routes.ts`: `path: '/api/problems/:id'` → `'/api/problems/:bojId'` (GET 엔드포인트만)
- `use-problems.ts`: `useProblem(id)` → `useProblem(bojId)` 파라미터명 정리
- `Problems.tsx`: `/solve/${problem.id}` → `/solve/${problem.bojId}`

> DELETE 엔드포인트는 기존대로 DB PK(`/api/problems/:id`)를 사용하여 변경 없음

### 3. shared/routes.ts — HTTP 상태코드 240 → 204

- `api.problems.delete.responses`에서 비표준 `240` → 표준 `204 No Content`로 수정
- 백엔드 `ProblemController.deleteProblem()`은 이미 `ResponseEntity.noContent().build()` (204)를 반환하고 있어 일치시킴

---

## 테스트 확인

- TypeScript 타입 체크: 기존 에러 외 새로운 에러 없음 (기존: shared 모듈 미설치 관련)
- Java 구문: switch expression, Files API 등 Java 17+ 호환 확인

---

## 영향 범위

- `server/src/main/java/com/algoarena/service/CompilerService.java`
- `server/src/main/java/com/algoarena/controller/ProblemController.java`
- `shared/routes.ts`
- `client/src/hooks/use-problems.ts`
- `client/src/pages/Problems.tsx`